### PR TITLE
changed fixed pool to cached pool, thread can be created as per the demand

### DIFF
--- a/app/uk/gov/hmrc/transitmovementsconverter/controllers/MessageConversionController.scala
+++ b/app/uk/gov/hmrc/transitmovementsconverter/controllers/MessageConversionController.scala
@@ -16,23 +16,20 @@
 
 package uk.gov.hmrc.transitmovementsconverter.controllers
 
+import cats.data.EitherT
+import cats.implicits.catsStdInstancesForFuture
 import org.apache.pekko.stream.Materializer
 import org.apache.pekko.stream.scaladsl.Sink
 import org.apache.pekko.stream.scaladsl.Source
 import org.apache.pekko.util.ByteString
-import cats.data.EitherT
-import cats.implicits.catsStdInstancesForFuture
 import play.api.http.HeaderNames
 import play.api.http.MimeTypes
-import play.api.http.Writeable
-import play.api.libs.json.JsValue
 import play.api.libs.json.Json
 import play.api.mvc.Action
 import play.api.mvc.ControllerComponents
-import play.api.mvc.Request
+import play.api.mvc.Result
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import uk.gov.hmrc.transitmovementsconverter.models.MessageType
-import uk.gov.hmrc.transitmovementsconverter.models.errors.ConversionError
 import uk.gov.hmrc.transitmovementsconverter.models.errors.PresentationError
 import uk.gov.hmrc.transitmovementsconverter.services.ConverterService
 import uk.gov.hmrc.transitmovementsconverter.stream.StreamingParsers
@@ -41,7 +38,6 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import scala.xml.NodeSeq
 
 @Singleton()
 class MessageConversionController @Inject() (cc: ControllerComponents, converterService: ConverterService)(implicit
@@ -51,45 +47,33 @@ class MessageConversionController @Inject() (cc: ControllerComponents, converter
     with StreamingParsers
     with ErrorTranslator {
 
-  def message(messageType: MessageType[_]): Action[Source[ByteString, _]] = route {
-    case (Some(MimeTypes.XML), Some(MimeTypes.JSON)) => convertMessage[JsValue](messageType, converterService.xmlToJson(_, _))
-    case (Some(MimeTypes.JSON), Some(MimeTypes.XML)) => convertMessage[NodeSeq](messageType, converterService.jsonToXml(_, _))
-  }
-
-  def convertMessage[A](messageType: MessageType[_], convert: (MessageType[_], Source[ByteString, _]) => EitherT[Future, ConversionError, A])(implicit
-    writable: Writeable[A]
-  ): Action[Source[ByteString, _]] = Action.async(streamFromMemory) {
+  def message(messageType: MessageType[_]): Action[Source[ByteString, _]] = Action.async(streamFromMemory) {
     implicit request =>
-      convert(messageType, request.body).asPresentation
-        .map(Ok(_))
-        .valueOr(
-          error => Status(error.code.statusCode)(Json.toJson(error))
-        )
-  }
-
-  private def route(routes: PartialFunction[(Option[String], Option[String]), Action[_]])(implicit materializer: Materializer): Action[Source[ByteString, _]] =
-    Action.async(streamFromMemory) {
-      (request: Request[Source[ByteString, _]]) =>
-        routes
-          .lift((request.headers.get(HeaderNames.CONTENT_TYPE), request.headers.get(HeaderNames.ACCEPT)))
-          .map(
-            action => action(request).run(request.body)
-          )
-          .getOrElse {
-            // To avoid a memory leak, we need to ensure we run the request stream and ignore it.
-            request.body.to(Sink.ignore).run()
-            val contentType = request.headers.get(HeaderNames.CONTENT_TYPE).getOrElse("[not supplied]")
-            val accept      = request.headers.get(HeaderNames.ACCEPT).getOrElse("[not supplied]")
-            Future.successful(
-              UnsupportedMediaType(
-                Json.toJson(
-                  PresentationError.unsupportedMediaTypeError(
-                    s"Combination of content-type header $contentType and accept header $accept is not supported!"
-                  )
-                )
-              )
+      val result: EitherT[Future, PresentationError, Result] = (request.headers.get(HeaderNames.CONTENT_TYPE), request.headers.get(HeaderNames.ACCEPT)) match {
+        case (Some(MimeTypes.XML), Some(MimeTypes.JSON)) =>
+          converterService
+            .xmlToJson(messageType, request.body)
+            .asPresentation
+            .map(Ok(_))
+        case (Some(MimeTypes.JSON), Some(MimeTypes.XML)) =>
+          converterService
+            .jsonToXml(messageType, request.body)
+            .asPresentation
+            .map(Ok(_))
+        case (Some(contentType), Some(accept)) =>
+          request.body.runWith(Sink.ignore)
+          EitherT.leftT(
+            PresentationError.unsupportedMediaTypeError(
+              s"Combination of Content-Type header $contentType and Accept header $accept is not supported!"
             )
-          }
-    }
+          )
+        case _ =>
+          request.body.runWith(Sink.ignore)
+          EitherT.leftT(PresentationError.unsupportedMediaTypeError("Content-Type header or Accept header or both were not supplied"))
+      }
+      result.valueOr(
+        presentationError => Status(presentationError.code.statusCode)(Json.toJson(presentationError))
+      )
+  }
 
 }

--- a/app/uk/gov/hmrc/transitmovementsconverter/stream/StreamingParsers.scala
+++ b/app/uk/gov/hmrc/transitmovementsconverter/stream/StreamingParsers.scala
@@ -31,11 +31,8 @@ trait StreamingParsers {
 
   implicit val materializer: Materializer
 
-  // TODO: do we choose a better thread pool, or make configurable?
-  //  We have to be careful to not use Play's EC because we could accidentally starve the thread pool
-  //  and cause errors for additional connections
   implicit val materializerExecutionContext: ExecutionContext =
-    ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(4))
+    ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
 
   lazy val streamFromMemory: BodyParser[Source[ByteString, _]] = BodyParser {
     _ =>

--- a/test/uk/gov/hmrc/transitmovementsconverter/controllers/MessageConversionControllerSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementsconverter/controllers/MessageConversionControllerSpec.scala
@@ -96,7 +96,7 @@ class MessageConversionControllerSpec
       status(result) mustBe UNSUPPORTED_MEDIA_TYPE
       contentAsJson(result) mustBe Json.obj(
         "code"    -> "UNSUPPORTED_MEDIA_TYPE",
-        "message" -> "Combination of content-type header [not supplied] and accept header [not supplied] is not supported!"
+        "message" -> "Content-Type header or Accept header or both were not supplied"
       )
       whenReady(resultMatVal) {
         _ mustBe "<valid></valid>" // testing we drain the stream
@@ -113,7 +113,7 @@ class MessageConversionControllerSpec
       status(result) mustBe UNSUPPORTED_MEDIA_TYPE
       contentAsJson(result) mustBe Json.obj(
         "code"    -> "UNSUPPORTED_MEDIA_TYPE",
-        "message" -> "Combination of content-type header text/plain and accept header application/json is not supported!"
+        "message" -> "Combination of Content-Type header text/plain and Accept header application/json is not supported!"
       )
       whenReady(resultMatVal) {
         _ mustBe "<valid></valid>" // testing we drain the stream
@@ -130,7 +130,7 @@ class MessageConversionControllerSpec
       status(result) mustBe UNSUPPORTED_MEDIA_TYPE
       contentAsJson(result) mustBe Json.obj(
         "code"    -> "UNSUPPORTED_MEDIA_TYPE",
-        "message" -> "Combination of content-type header application/xml and accept header text/plain is not supported!"
+        "message" -> "Combination of Content-Type header application/xml and Accept header text/plain is not supported!"
       )
       whenReady(resultMatVal) {
         _ mustBe "<valid></valid>" // testing we drain the stream


### PR DESCRIPTION
Its look like same thread is trying to use the source multiple times with concurrent request so causing subscription issue.
I have changed fixed thread pool to cached thread pool so that threads can be created as per the demands.
Simplified the logic to use memory and request.body one time